### PR TITLE
sequential_hcl with constant chroma

### DIFF
--- a/make_docs/temporary_pages/getstarted.qmd
+++ b/make_docs/temporary_pages/getstarted.qmd
@@ -39,7 +39,7 @@ wavelength), chroma (= colorfulness), luminance (= brightness).
 
 from colorspace import palette, sequential_hcl, swatchplot
 
-H = palette(sequential_hcl(h = [0, 300], c = 60, l = 65).colors(5), "Hue")
+H = palette(sequential_hcl(h = [0, 300], c = [60, 60], l = 65).colors(5), "Hue")
 C = palette(sequential_hcl(h = 0, c = [0, 100], l = 65).colors(5), "Chroma")
 L = palette(sequential_hcl(h = 0, c = 0, l = [90, 25]).colors(5), "Luminance")
 

--- a/src/colorspace/palettes.py
+++ b/src/colorspace/palettes.py
@@ -1908,7 +1908,7 @@ class sequential_hcl(hclpalette):
             input `h` is a str this argument acts like the `palette` argument
             (see `palette` input parameter).
         c (numeric list): Chroma values (colorfullness), numeric of length one
-            (constant chroma), two (linear), or three (advanced; [c1, c2, cmax]).
+            (linear to zero), two (linear in interval), or three (advanced; [c1, c2, cmax]).
         l (numeric list): Luminance values (luminance), numeric of length two.
             If multiple values are provided only the first one will be used.
         power (numeric, numeric list): Power parameter for non-linear behaviour


### PR DESCRIPTION
Reto @retostauffer, the documentation claimed that `sequential_hcl(..., c = 60, ...)` would yield a palette with constant chroma. However, this is not true: In that case chroma changes linearly between 60 and 0. The code is consistent with the R implementation.

So I changed the docs (feel free to improve further) and modified the example in the "Get started" vignette.