### PR TITLE
venv activation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ venv: requirements_devel.txt
 	-rm -rf venv
 	virtualenv -p 3 venv
 	venv/bin/pip install -r requirements_devel.txt
-	source venv/bin/activate && make install
 	
 # Install Python colorspace.
 install: setup.py

--- a/_quarto/installation.qmd
+++ b/_quarto/installation.qmd
@@ -102,14 +102,17 @@ and extended (additional dependencies) tests.
 # Cloning current main branch
 git clone https://github.com/retostauffer/python-colorspace.git
 
-# Creates a fresh `softvenv` virtual environment and runs soft tests
+# Changing directory
+cd python-colorspace
+
+# Creating a fresh `softvenv` virtual environment and running soft tests
 make softtest
 
 # Setting up virtual environment with all dependencies for full
 # tests as well as for creating the documentation, calculating
-# coverage etc., install Python colorspace, activate venv and
-# run full tests.
-make venv && make install && source venv/bin/activate && make test
+# coverage etc., activating venv, installing Python colorspace, and
+# running full tests.
+make venv && source venv/bin/activate && make install && make test
 ```
 
 ### Development


### PR DESCRIPTION
Reto @retostauffer, in the review by @dmreagan in #24 it turned out that [L31](https://github.com/retostauffer/python-colorspace/blob/main/Makefile#L31C2-L31C42) of the "venv" target in the `Makefile` does not run, at least on some systems:

    source venv/bin/activate && make install

This tries to first activate the virtual environment and then run the "install" target. Following a [discussion on StackOverflow](https://stackoverflow.com/questions/33839018/activate-virtualenv-in-makefile) the alternative would be to use

    . venv/bin/activate && make install

which worked on my system. However, given that other places of the documentation advise the users to activate the virtual environment themselves after running the "venv" target, I thought it would be cleaner to just remove this line.

I've changed the installation documentation correspondingly and make sure that the virtual environment is activated before running the "install" and "test" targets. This works on my system.

Let me know if you want to resolve this in a different way.

Final note: It seems that the "cov" target assumes that the virtual environment is activated somehow. I did not test this myself, but this might need adaptation.